### PR TITLE
Corrected the service name in work_leave.proto file

### DIFF
--- a/proto/work_leave.proto
+++ b/proto/work_leave.proto
@@ -4,7 +4,7 @@ package work_leave; //Optional: unique package name.
 
 //Service. define the methods that the grpc server can expose to the client.
 service EmployeeLeaveDaysService {
-  rpc EligibleForLeave (Employee) returns (LeaveEligibility);
+  rpc eligibleForLeave (Employee) returns (LeaveEligibility);
   rpc grantLeave (Employee) returns (LeaveFeedback);
 }
 


### PR DESCRIPTION
Replaced "**E**ligibleForLeave" with "**e**ligibleForLeave" (i.e. e in lowercase) in the file as the later is correct.

It otherwise resulted in below error:

Error: Error: 12 UNIMPLEMENTED: RPC method not implemented /work_leave.EmployeeLeaveDaysService/EligibleForLeave